### PR TITLE
PHPUnit required to run tests. Documents how to test the package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+composer.lock
+composer.phar
+vendor/

--- a/README.md
+++ b/README.md
@@ -28,13 +28,64 @@ composer require pear/net_dns2
 
 Or download the source above.
 
+
 ## Requirements ##
 
 * PHP 5.1.2+
 * The PHP INI setting `mbstring.func_overload` equals 0, 1, 4, or 5.
 
+### Running the test suite ###
+
+If PHPUnit is already installed, use it:
+
+```
+$ phpunit tests/AllTests.php
+```
+
+Otherwise, install PHPUnit according to its [directions][1] or with Composer:
+
+```
+$ curl -sSO getcomposer.org/installer | php
+$ composer install
+$ vendor/bin/phpunit
+```
 
 ## Using Net\_DNS2 ##
 
+Using Net_DNS2 is simple:
+
+```
+// First, create the resolver
+$resolver = new \Net_DNS2_Resolver();
+
+// Then, ask the resolver for resource record sets for any domain:
+// Here, the domain is Google and the RR set is the Start Of Authority
+try {
+    $result = $resolver->query('google.com', 'SOA');
+} catch(\Net_DNS2_Exception $ex) {
+    die($ex->getMessage());
+}
+
+// Finally, iterate over each resource record:
+foreach ($result->answer as $answer) {
+    // echo out to get a printable dump in zone file format:
+    echo $answer . PHP_EOL;
+
+    // or extract specific details with member variables:
+    printf(
+        '%s %d %s %s %d %d %d %d' . PHP_EOL,
+        $answer->name,
+        $answer->ttl,
+        $answer->class,
+        $answer->type,
+        $answer->refresh,
+        $answer->retry,
+        $answer->minimum,
+        $answer->expire
+    );
+}
+```
+
 See the Net\_DNS2 Website for more details - https://netdns2.com/
 
+[1]: https://phpunit.de/manual/current/en/installation.html

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ Or download the source above.
 * PHP 5.1.2+
 * The PHP INI setting `mbstring.func_overload` equals 0, 1, 4, or 5.
 
-### Running the test suite ###
+### Checking requirements ###
 
-If PHPUnit is already installed, use it:
+Run the provided test suite to ensure Net\_DNS2 is compatible. If PHPUnit is
+already installed, use it:
 
 ```
 $ phpunit tests/AllTests.php

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ phpunit tests/AllTests.php
 Otherwise, install PHPUnit according to its [directions][1] or with Composer:
 
 ```
-$ curl -sSO getcomposer.org/installer | php
+$ curl -sS https://getcomposer.org/installer | php
 $ composer install
 $ vendor/bin/phpunit
 ```

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
     },
     "autoload": {
         "psr-0": { "Net_DNS2": "" }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.1"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -50,17 +50,16 @@
  *
  */
 
-error_reporting(E_ALL | E_STRICT);
+require_once __DIR__ . '/bootstrap.php';
 
 if (!defined('PHPUNIT_MAIN_METHOD')) {
     define('PHPUNIT_MAIN_METHOD', 'Net_DNS2_AllTests::main');
 }
 
+require_once 'Net_DNS2_EnvironmentTest.php';
 require_once 'Net_DNS2_ParserTest.php';
 require_once 'Net_DNS2_ResolverTest.php';
 require_once 'Net_DNS2_DNSSECTest.php';
-
-set_include_path('..:.');
 
 /**
  * This test suite assumes that Net_DNS2 will be in the include path, otherwise it
@@ -99,6 +98,7 @@ class Net_DNS2_AllTests
     {
         $suite = new PHPUnit_Framework_TestSuite('PEAR - Net_DNS2');
 
+        $suite->addTestSuite('Net_DNS2_EnvironmentTest');
         $suite->addTestSuite('Net_DNS2_ParserTest');
         $suite->addTestSuite('Net_DNS2_ResolverTest');
         $suite->addTestSuite('Net_DNS2_DNSSECTest');

--- a/tests/Net_DNS2_EnvironmentTest.php
+++ b/tests/Net_DNS2_EnvironmentTest.php
@@ -51,37 +51,32 @@
  */
 
 /**
- * Test class to test the DNSSEC logic
+ * Tests that the test environment meets our library preconditions. If any
+ * of these tests fail, the results from any other tests are dubious.
  *
  * @category Networking
  * @package  Net_DNS2
- * @author   Mike Pultz <mike@mikepultz.com>
+ * @author   Bishop Bettini <bishop@php.net>
  * @license  http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link     http://pear.php.net/package/Net_DNS2
  *
  */
-class Net_DNS2_DNSSECTest extends PHPUnit_Framework_TestCase
+class Net_DNS2_EnvironmentTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * function to test the TSIG logic
+     * function to test the mbstring.func_overload setting.
      *
      * @return void
      * @access public
      *
      */
-    public function testDNSSEC()
+    public function testMbstringFuncOverload()
     {
-        $ns = array('8.8.8.8', '8.8.4.4');
-
-        $r = new Net_DNS2_Resolver(array('nameservers' => $ns));
-
-        $r->dnssec = true;
-
-        $result = $r->query('org', 'SOA', 'IN');
-
-        $this->assertTrue(($result->header->ad == 1));
-        $this->assertTrue(($result->additional[0] instanceof Net_DNS2_RR_OPT));
-        $this->assertTrue(($result->additional[0]->do == 1));
+        $this->assertContains(
+            (int)ini_get('mbstring.func_overload'),
+            array (0, 1, 4, 5),
+            'The INI setting "mbstring.func_overload" must be either 0, 1, 4, or 5.'
+        );
     }
 }
 

--- a/tests/Net_DNS2_ParserTest.php
+++ b/tests/Net_DNS2_ParserTest.php
@@ -50,9 +50,6 @@
  *
  */
 
-require_once '../Net/DNS2.php';
-
-
 /**
  * Test class to test the parsing code
  *   

--- a/tests/Net_DNS2_ResolverTest.php
+++ b/tests/Net_DNS2_ResolverTest.php
@@ -50,8 +50,6 @@
  *
  */
 
-require_once '../Net/DNS2.php';
-
 /**  
  * This test uses the Google public DNS servers to perform a resolution test; 
  * this should work on *nix and Windows, but will require an internet connection.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,43 +46,40 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @version   SVN: $Id$
  * @link      http://pear.php.net/package/Net_DNS2
- * @since     File available since Release 1.0.0
+ * @since     File available since Release 1.4.2
  *
  */
 
 /**
- * Test class to test the DNSSEC logic
- *
- * @category Networking
- * @package  Net_DNS2
- * @author   Mike Pultz <mike@mikepultz.com>
- * @license  http://www.opensource.org/licenses/bsd-license.php  BSD License
- * @link     http://pear.php.net/package/Net_DNS2
- *
+ * Bootstrap the testing environment.
  */
-class Net_DNS2_DNSSECTest extends PHPUnit_Framework_TestCase
-{
-    /**
-     * function to test the TSIG logic
-     *
-     * @return void
-     * @access public
-     *
-     */
-    public function testDNSSEC()
-    {
-        $ns = array('8.8.8.8', '8.8.4.4');
 
-        $r = new Net_DNS2_Resolver(array('nameservers' => $ns));
+//
+// Crank error reporting to max volume, and do this first so that
+// that we can see whatever PHP might complain about.
+//
+error_reporting(E_ALL | E_STRICT);
 
-        $r->dnssec = true;
+//
+// If we have composer autoloading, use that.
+//
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
 
-        $result = $r->query('org', 'SOA', 'IN');
-
-        $this->assertTrue(($result->header->ad == 1));
-        $this->assertTrue(($result->additional[0] instanceof Net_DNS2_RR_OPT));
-        $this->assertTrue(($result->additional[0]->do == 1));
+//
+// Otherwise, if we're running inside PHPUnit, load all our files the
+// manual way.
+//
+} else if (class_exists('PHPUnit_Framework_TestCase')) {
+    set_include_path(__DIR__ . '/..' . PATH_SEPARATOR . __DIR__);
+    require_once __DIR__ . '/../Net/DNS2.php';
+    foreach (glob(__DIR__ . '/*Test.php') as $file) {
+        require_once $file;
     }
-}
 
-?>
+//
+// Otherwise, we're dead in the water.
+//
+} else {
+    die('PHPUnit not installed. Refer to README.md for how to run tests.' . PHP_EOL);
+}


### PR DESCRIPTION
Addresses Issue #44 :

* Adds phpunit as a dev dependency, allowing the package to be self-sufficient for testing (and refactors global PHPUnit usage to use same).
* Adds test to check that mbstring.func_overload setting is correct.
* Adds usage example to README to save users some click digging.

I prefer dependencies explicitly listed in `composer.json`. As PHPUnit is a *dev* dependency, and Net_DNS2 is a library package (ie, not a root package) , consumers will not be subjected to conform to Net_DNS2 dev dependencies.

The EnvironmentTest should strictly be a separate PR, as it's unrelated to what's going on in this PR, but it was on my mind and I don't think it hurts to pull it in here.  I can always separate it if deemed necessary.