### PR TITLE
Allow looking up root zone records

### DIFF
--- a/Net/DNS2/Resolver.php
+++ b/Net/DNS2/Resolver.php
@@ -229,7 +229,7 @@ class Net_DNS2_Resolver extends Net_DNS2
             //
             foreach ($response->answer as $index => $object) {
 
-                if ( (strcasecmp($object->name, $name) == 0)
+                if ( (strcasecmp($object->name, $packet->name) == 0)
                     && ($object->type == $type)
                     && ($object->class == $class)
                 ) {


### PR DESCRIPTION
Looking up records on the root zone (e.g. `$r->query('com', 'DS')` ) fails, because the resolver adds `$r->domain`.  Even if this is empty, `$name` becomes `com.` (with a trailing dot), so it does not match the name returned by the nameserver, and `$response->answers` thus becomes empty.