### PR TITLE
Handle empty bitmap-type

### DIFF
--- a/Net/DNS2/BitMap.php
+++ b/Net/DNS2/BitMap.php
@@ -77,7 +77,7 @@ class Net_DNS2_BitMap
     public static function bitMapToArray($data)
     {
         if (strlen($data) == 0) {
-            return null;
+            return array();
         }
 
         $output = array();
@@ -141,7 +141,7 @@ class Net_DNS2_BitMap
     public static function arrayToBitMap(array $data)
     {
         if (count($data) == 0) {
-            return null;
+            return '';
         }
 
         $current_window = 0;


### PR DESCRIPTION
When a record (eg: NSEC3) has an empty bitmap, function toString crash with invalid type parameter.

I propose to correct only Bitmap file in order to respect as documented return type.