### PR TITLE
Some phpdoc and code fixes found by phpstan

### DIFF
--- a/Net/DNS2.php
+++ b/Net/DNS2.php
@@ -734,7 +734,7 @@ class Net_DNS2
     /**
      * a simple function to determine if the RR type is cacheable
      *
-     * @param stream $_type the RR type string
+     * @param string $_type the RR type string
      *
      * @return bool returns true/false if the RR type if cachable
      * @access public

--- a/Net/DNS2/PrivateKey.php
+++ b/Net/DNS2/PrivateKey.php
@@ -257,7 +257,7 @@ class Net_DNS2_PrivateKey
             switch(strtolower($key)) {
 
             case 'private-key-format':
-                $this->_key_format = $value;
+                $this->key_format = $value;
                 break;
 
             case 'algorithm':

--- a/Net/DNS2/RR/NIMLOC.php
+++ b/Net/DNS2/RR/NIMLOC.php
@@ -50,7 +50,7 @@
  */
 
 /**
- * NIMLOCK Resource Record - undefined; the rdata is simply used as-is in it's
+ * NIMLOC Resource Record - undefined; the rdata is simply used as-is in it's
  *                              binary format, so not process has to be done.
  * 
  * @category Networking
@@ -61,7 +61,7 @@
  * @see      Net_DNS2_RR
  *
  */
-class Net_DNS2_RR_NIMLOCK extends Net_DNS2_RR
+class Net_DNS2_RR_NIMLOC extends Net_DNS2_RR
 {
     /**
      * method to return the rdata portion of the packet as a string

--- a/Net/DNS2/Resolver.php
+++ b/Net/DNS2/Resolver.php
@@ -82,7 +82,7 @@ class Net_DNS2_Resolver extends Net_DNS2
      * @param string $type  the name of the RR type to lookup
      * @param string $class the name of the RR class to lookup
      *
-     * @return Net_DNS2_RR object
+     * @return Net_DNS2_Packet_Response object
      * @throws Net_DNS2_Exception
      * @access public
      *

--- a/Net/DNS2/Socket/Streams.php
+++ b/Net/DNS2/Socket/Streams.php
@@ -102,8 +102,8 @@ class Net_DNS2_Socket_Streams extends Net_DNS2_Socket
         //
         // create socket
         //
-        $errno;
-        $errstr;
+        $errno = '';
+        $errstr = '';
 
         switch($this->type) {
         case Net_DNS2_Socket::SOCK_STREAM:


### PR DESCRIPTION
I used phpstan to analyse the code and found some issue.

```
composer require --dev phpstan/phpstan-shim '^0.10' --ignore-platform-reqs
```

cat phpstan.neon
```
parameters:
    level: max
    paths:
        - Net
        - test
    autoload_files:
    ignoreErrors:
        - '#PHPDoc tag .*#'
```

```
./vendor/bin/phpstan.phar analyse
```

Output (all the phpdoc warnings are ignored for now):
```


 ------ ---------------------------------------------------------------------------------------------------------------------------- 
  Line   Net/DNS2.php                                                                                                                
 ------ ---------------------------------------------------------------------------------------------------------------------------- 
  536    Argument of an invalid type array<int, string>|false supplied for foreach, only iterables are supported.                    
  611    Instanceof between string and Net_DNS2_RR_TSIG will always evaluate to false.                                               
  663    Instanceof between string and Net_DNS2_RR_SIG will always evaluate to false.                                                
  805    Strict comparison using === between string and false will always evaluate to false.                                         
  843    Strict comparison using === between string and false will always evaluate to false.                                         
  894    Parameter #4 $request of class Net_DNS2_Exception constructor expects Net_DNS2_Packet_Request|null, Net_DNS2_Packet given.  
  997    Parameter #4 $request of class Net_DNS2_Exception constructor expects Net_DNS2_Packet_Request|null, Net_DNS2_Packet given.  
  1017   Parameter #4 $request of class Net_DNS2_Exception constructor expects Net_DNS2_Packet_Request|null, Net_DNS2_Packet given.  
  1035   Parameter #4 $request of class Net_DNS2_Exception constructor expects Net_DNS2_Packet_Request|null, Net_DNS2_Packet given.  
  1091   Parameter #2 $code of class Net_DNS2_Exception constructor expects int, string given.                                       
  1155   Parameter #1 $_proto of method Net_DNS2::generateError() expects string, int given.                                         
  1155   Parameter #3 $_error of method Net_DNS2::generateError() expects string, int given.                                         
  1165   Parameter #1 $_proto of method Net_DNS2::generateError() expects string, int given.                                         
  1165   Parameter #3 $_error of method Net_DNS2::generateError() expects string, int given.                                         
  1199   Parameter #1 $_proto of method Net_DNS2::generateError() expects string, int given.                                         
  1199   Parameter #3 $_error of method Net_DNS2::generateError() expects string, int given.                                         
  1286   Parameter #1 $_proto of method Net_DNS2::generateError() expects string, int given.                                         
  1286   Parameter #3 $_error of method Net_DNS2::generateError() expects string, int given.                                         
  1298   Cannot access property $response_time on Net_DNS2_Packet_Response|null.                                                     
  1304   Cannot access property $answer_from on Net_DNS2_Packet_Response|null.                                                       
  1305   Cannot access property $answer_socket_type on Net_DNS2_Packet_Response|null.                                                
  1310   Method Net_DNS2::sendTCPRequest() should return Net_DNS2_Packet_Response but returns Net_DNS2_Packet_Response|null.         
  1373   Parameter #1 $_proto of method Net_DNS2::generateError() expects string, int given.                                         
  1373   Parameter #3 $_error of method Net_DNS2::generateError() expects string, int given.                                         
  1382   Parameter #1 $_proto of method Net_DNS2::generateError() expects string, int given.                                         
  1382   Parameter #3 $_error of method Net_DNS2::generateError() expects string, int given.                                         
  1393   Parameter #1 $_proto of method Net_DNS2::generateError() expects string, int given.                                         
  1393   Parameter #3 $_error of method Net_DNS2::generateError() expects string, int given.                                         
 ------ ---------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   Net/DNS2/BitMap.php                                                                           
 ------ ---------------------------------------------------------------------------------------------- 
  98     Parameter #2 $start of function substr expects int, float|int given.                          
  238    Parameter #1 $var of function count expects array|Countable, array<int, string>|false given.  
  240    Parameter #1 $str of function strrev expects string, string|null given.                       
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   Net/DNS2/Cache.php                                                           
 ------ ----------------------------------------------------------------------------- 
  257    Parameter #1 $string of function strlen expects string, string|false given.  
  259    Parameter #1 $string of function strlen expects string, string|false given.  
 ------ ----------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------- 
  Line   Net/DNS2/Cache/File.php                                                                            
 ------ --------------------------------------------------------------------------------------------------- 
  104    Parameter #2 $length of function fread expects int, int|false given.                               
  110    Parameter #1 $json of function json_decode expects string, string|false given.                     
  113    Parameter #1 $variable_representation of function unserialize expects string, string|false given.  
  181    Parameter #2 $length of function fread expects int, int|false given.                               
 ------ --------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------- 
  Line   Net/DNS2/Cache/Shm.php                                                            
 ------ ---------------------------------------------------------------------------------- 
  217    Strict comparison using === between int and false will always evaluate to false.  
  286    Strict comparison using === between int and false will always evaluate to false.  
 ------ ---------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------ 
  Line   Net/DNS2/Exception.php                                                                                
 ------ ------------------------------------------------------------------------------------------------------ 
  101    Parameter #3 $previous of method Exception::__construct() expects Throwable|null, object|null given.  
 ------ ------------------------------------------------------------------------------------------------------ 

 ------ ---------------------------------------------------------------------------- 
  Line   Net/DNS2/Packet.php                                                         
 ------ ---------------------------------------------------------------------------- 
  223    Parameter #1 $string of function strlen expects string, string|null given.  
  234    Parameter #1 $str of function substr expects string, string|null given.     
  271    Parameter #1 $string of function strlen expects string, string|null given.  
 ------ ---------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------- 
  Line   Net/DNS2/Packet/Request.php                                                                      
 ------ ------------------------------------------------------------------------------------------------- 
  80     Parameter #2 $type of method Net_DNS2_Packet_Request::set() expects string, string|null given.   
  80     Parameter #3 $class of method Net_DNS2_Packet_Request::set() expects string, string|null given.  
  174    Parameter #1 $input of function array_reverse expects array, array<int, string>|false given.     
 ------ ------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------- 
  Line   Net/DNS2/PrivateKey.php                                                                                   
 ------ ---------------------------------------------------------------------------------------------------------- 
  242    Parameter #1 $var of function count expects array|Countable, array<int, string>|false given.              
  250    Argument of an invalid type array<int, string>|false supplied for foreach, only iterables are supported.  
  402    Parameter #1 $message of class Net_DNS2_Exception constructor expects string, string|false given.         
 ------ ---------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------- 
  Line   Net/DNS2/RR.php                                                                                           
 ------ ---------------------------------------------------------------------------------------------------------- 
  359    Call to an undefined method Net_DNS2_RR::preBuild().                                                      
  533    Parameter #1 $var of function count expects array|Countable, array<int, string>|false given.              
  544    Parameter #1 $stack of function array_shift expects array, array<int, string>|false given.                
  549    Argument of an invalid type array<int, string>|false supplied for foreach, only iterables are supported.  
  554    Parameter #1 $stack of function array_shift expects array, array<int, string>|false given.                
  563    Parameter #1 $stack of function array_shift expects array, array<int, string>|false given.                
  568    Parameter #1 $stack of function array_shift expects array, array<int, string>|false given.                
  573    Parameter #1 $stack of function array_shift expects array, array<int, string>|false given.                
 ------ ---------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------- 
  Line   Net/DNS2/RR/APL.php                                             
 ------ ---------------------------------------------------------------- 
  259    Parameter #1 $ascii of function chr expects int, string given.  
 ------ ---------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   Net/DNS2/RR/DHCID.php                                                        
 ------ ----------------------------------------------------------------------------- 
  118    Parameter #1 $string of function strlen expects string, string|false given.  
  123    Parameter #2 $data of function unpack expects string, string|false given.    
  131    Parameter #1 $str of function substr expects string, string|false given.     
  131    Parameter #1 $string of function strlen expects string, string|false given.  
 ------ ----------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   Net/DNS2/RR/HIP.php                                                          
 ------ ----------------------------------------------------------------------------- 
  166    Parameter #1 $string of function strlen expects string, string|false given.  
 ------ ----------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Net/DNS2/RR/IPSECKEY.php                                              
 ------ ---------------------------------------------------------------------- 
  302    Parameter #2 $start of function substr expects int, float|int given.  
 ------ ---------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------- 
  Line   Net/DNS2/RR/LOC.php                                                                    
 ------ --------------------------------------------------------------------------------------- 
  352    Method Net_DNS2_RR_LOC::_precsizeNtoA() should return string but returns (float|int).  
  374    Binary operation "<<" between float|int|string and 4 results in an error.              
 ------ --------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   Net/DNS2/RR/NSEC3.php                                                        
 ------ ----------------------------------------------------------------------------- 
  185    Parameter #1 $string of function strlen expects string, string|false given.  
  237    Parameter #2 $start of function substr expects int, float|int given.         
  246    Parameter #2 $start of function substr expects int, float|int given.         
 ------ ----------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   Net/DNS2/RR/OPENPGPKEY.php                                                   
 ------ ----------------------------------------------------------------------------- 
  143    Parameter #1 $string of function strlen expects string, string|false given.  
 ------ ----------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Net/DNS2/RR/RRSIG.php                                                 
 ------ ---------------------------------------------------------------------- 
  248    Parameter #2 $start of function substr expects int, float|int given.  
 ------ ---------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------- 
  Line   Net/DNS2/RR/SIG.php                                                                                
 ------ --------------------------------------------------------------------------------------------------- 
  253    Parameter #2 $start of function substr expects int, float|int given.                               
  310    Parameter #1 $ascii of function chr expects int, string given.                                     
  417    Parameter #1 $message of class Net_DNS2_Exception constructor expects string, string|false given.  
 ------ --------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Net/DNS2/RR/TKEY.php                                                  
 ------ ---------------------------------------------------------------------- 
  229    Parameter #2 $start of function substr expects int, float|int given.  
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------- 
  Line   Net/DNS2/RR/TSIG.php                                                                                
 ------ ---------------------------------------------------------------------------------------------------- 
  263    Parameter #2 $start of function substr expects int, float|int given.                                
  298    Parameter #2 $start of function substr expects int, float|int given.                                
  377    Parameter #2 $key of method Net_DNS2_RR_TSIG::_signHMAC() expects string|null, string|false given.  
  458    Parameter #3 $key of function hash_hmac expects string, string|null given.                          
  488    Binary operation "^" between string and string results in an error.                                 
  489    Binary operation "^" between string and string results in an error.                                 
 ------ ---------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------- 
  Line   Net/DNS2/RR/TXT.php                                                         
 ------ ---------------------------------------------------------------------------- 
  164    Parameter #1 $string of function strlen expects string, string|null given.  
 ------ ---------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------- 
  Line   Net/DNS2/Socket/Sockets.php                                                       
 ------ ---------------------------------------------------------------------------------- 
  148    Strict comparison using === between int and false will always evaluate to false.  
  204    Strict comparison using === between int and false will always evaluate to false.  
  271    Strict comparison using === between int and false will always evaluate to false.  
  292    Strict comparison using === between int and false will always evaluate to false.  
  336    Strict comparison using === between int and false will always evaluate to false.  
 ------ ---------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------- 
  Line   Net/DNS2/Socket/Streams.php                                                                
 ------ ------------------------------------------------------------------------------------------- 
  171    Parameter #2 $mode of function stream_set_blocking expects bool, int given.                
  218    Parameter #1 $read_streams of function stream_select expects array<resource>, null given.  
  276    Parameter #2 $mode of function stream_set_blocking expects bool, int given.                
  309    Parameter #1 $character of function ord expects string, string|null given.                 
  309    Parameter #1 $character of function ord expects string, string|null given.                 
  323    Parameter #2 $mode of function stream_set_blocking expects bool, int given.                
  376    Parameter #1 $string of function strlen expects string, string|false given.                
 ------ ------------------------------------------------------------------------------------------- 

 ------ --------------------------------------- 
  Line   test                                   
 ------ --------------------------------------- 
         Path /tmp/netdns2/test does not exist  
 ------ --------------------------------------- 

 [ERROR] Found 95 errors                                                                                                
```

There are some additional errors who might be worth looking into. E.g:
```
 ------ ---------------------------------------------------------------------------------- 
  Line   Net/DNS2/Socket/Sockets.php                                                       
 ------ ---------------------------------------------------------------------------------- 
  148    Strict comparison using === between int and false will always evaluate to false.  

 ------ --------------------------------------------------------------------------------------------------------------------- 
  Line   Net/DNS2.php                                                                                                         
 ------ --------------------------------------------------------------------------------------------------------------------- 
  611    Instanceof between string and Net_DNS2_RR_TSIG will always evaluate to false.                                        
  663    Instanceof between string and Net_DNS2_RR_SIG will always evaluate to false.

 ------ --------------------------------------------------------------------- 
  Line   Net/DNS2/RR/TSIG.php                                                 
 ------ --------------------------------------------------------------------- 
  488    Binary operation "^" between string and string results in an error. 
```