### PR TITLE
URI records contain URIs not host names

### DIFF
--- a/Net/DNS2/RR/URI.php
+++ b/Net/DNS2/RR/URI.php
@@ -98,7 +98,7 @@ class Net_DNS2_RR_URI extends Net_DNS2_RR
         // presentation format has double quotes (") around the target.
         //
         return $this->priority . ' ' . $this->weight . ' "' . 
-            $this->cleanString($this->target) . '"';
+           $this->target . '"';
     }
 
     /**
@@ -114,11 +114,7 @@ class Net_DNS2_RR_URI extends Net_DNS2_RR
     {
         $this->priority = $rdata[0];
         $this->weight   = $rdata[1];
-
-        //
-        // make sure to trim the lead/trailing double quote if it's there.
-        //
-        $this->target   = trim($this->cleanString($rdata[2]), '"');
+        $this->target   = trim($rdata[2], '"');
         
         return true;
     }
@@ -143,9 +139,7 @@ class Net_DNS2_RR_URI extends Net_DNS2_RR
 
             $this->priority = $x['priority'];
             $this->weight   = $x['weight'];
-
-            $offset         = $packet->offset + 4;
-            $this->target   = Net_DNS2_Packet::expand($packet, $offset);
+            $this->target   = substr($this->rdata, 4);
 
             return true;
         }


### PR DESCRIPTION
The `rrToString()` and `rrSet()` methods of `Net_DNS2_RR_URI` used `cleanString()` and `Net_DNS2_Packet::expand()` (respectively) to munge the final part of the RR's rdata.

However these functions assume that what they are being given is a domain name, but a URI is not a domain name: for example, a trailing dot is permissable in URIs and should be preserved, and URIs are not compressed in the same way that domain names are in packets, so the `target` property of a `Net_DNS2_RR_URI` record is always `NULL` as `Net_DNS2_Packet::expand()` will always return `NULL` if it cannot successfully expand a compressed name.

This pull request fixes the `rrToString()` and `rrSet()` methods of `Net_DNS2_RR_URI`.