### PR TITLE
Change protected function rrToString to public function rrToString

### DIFF
--- a/Net/DNS2/RR.php
+++ b/Net/DNS2/RR.php
@@ -129,7 +129,7 @@ abstract class Net_DNS2_RR
      * @access protected
      *
      */
-    abstract protected function rrToString();
+    abstract public function rrToString();
 
     /**
      * abstract definition - parses a RR from a standard DNS config line

--- a/Net/DNS2/RR/A.php
+++ b/Net/DNS2/RR/A.php
@@ -78,7 +78,7 @@ class Net_DNS2_RR_A extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->address;
     }

--- a/Net/DNS2/RR/AAAA.php
+++ b/Net/DNS2/RR/AAAA.php
@@ -88,7 +88,7 @@ class Net_DNS2_RR_AAAA extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->address;
     }

--- a/Net/DNS2/RR/AFSDB.php
+++ b/Net/DNS2/RR/AFSDB.php
@@ -86,7 +86,7 @@ class Net_DNS2_RR_AFSDB extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->subtype . ' ' . $this->cleanString($this->hostname) . '.';
     }

--- a/Net/DNS2/RR/ANY.php
+++ b/Net/DNS2/RR/ANY.php
@@ -69,7 +69,7 @@ class Net_DNS2_RR_ANY extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return '';
     }

--- a/Net/DNS2/RR/APL.php
+++ b/Net/DNS2/RR/APL.php
@@ -83,7 +83,7 @@ class Net_DNS2_RR_APL extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         $out = '';
 

--- a/Net/DNS2/RR/ATMA.php
+++ b/Net/DNS2/RR/ATMA.php
@@ -89,7 +89,7 @@ class Net_DNS2_RR_ATMA extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->address;
     }

--- a/Net/DNS2/RR/CAA.php
+++ b/Net/DNS2/RR/CAA.php
@@ -92,7 +92,7 @@ class Net_DNS2_RR_CAA extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->flags . ' ' . $this->tag . ' "' . 
             trim($this->cleanString($this->value), '"') . '"';

--- a/Net/DNS2/RR/CERT.php
+++ b/Net/DNS2/RR/CERT.php
@@ -149,7 +149,7 @@ class Net_DNS2_RR_CERT extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->format . ' ' . $this->keytag . ' ' . $this->algorithm . 
             ' ' . base64_encode($this->certificate);

--- a/Net/DNS2/RR/CNAME.php
+++ b/Net/DNS2/RR/CNAME.php
@@ -79,7 +79,7 @@ class Net_DNS2_RR_CNAME extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->cleanString($this->cname) . '.';
     }

--- a/Net/DNS2/RR/CSYNC.php
+++ b/Net/DNS2/RR/CSYNC.php
@@ -93,7 +93,7 @@ class Net_DNS2_RR_CSYNC extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         $out = $this->serial . ' ' . $this->flags;
 

--- a/Net/DNS2/RR/DHCID.php
+++ b/Net/DNS2/RR/DHCID.php
@@ -95,7 +95,7 @@ class Net_DNS2_RR_DHCID extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         $out = pack('nC', $this->id_type, $this->digest_type);
         $out .= base64_decode($this->digest);

--- a/Net/DNS2/RR/DNAME.php
+++ b/Net/DNS2/RR/DNAME.php
@@ -79,7 +79,7 @@ class Net_DNS2_RR_DNAME extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->cleanString($this->dname) . '.';
     }

--- a/Net/DNS2/RR/DNSKEY.php
+++ b/Net/DNS2/RR/DNSKEY.php
@@ -98,7 +98,7 @@ class Net_DNS2_RR_DNSKEY extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->flags . ' ' . $this->protocol . ' ' . 
             $this->algorithm . ' ' . $this->key;

--- a/Net/DNS2/RR/DS.php
+++ b/Net/DNS2/RR/DS.php
@@ -98,7 +98,7 @@ class Net_DNS2_RR_DS extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->keytag . ' ' . $this->algorithm . ' ' . 
             $this->digesttype . ' ' . $this->digest;

--- a/Net/DNS2/RR/EID.php
+++ b/Net/DNS2/RR/EID.php
@@ -70,7 +70,7 @@ class Net_DNS2_RR_EID extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return '';
     }

--- a/Net/DNS2/RR/EUI48.php
+++ b/Net/DNS2/RR/EUI48.php
@@ -82,7 +82,7 @@ class Net_DNS2_RR_EUI48 extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->address;
     }

--- a/Net/DNS2/RR/EUI64.php
+++ b/Net/DNS2/RR/EUI64.php
@@ -81,7 +81,7 @@ class Net_DNS2_RR_EUI64 extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->address;
     }

--- a/Net/DNS2/RR/HINFO.php
+++ b/Net/DNS2/RR/HINFO.php
@@ -85,7 +85,7 @@ class Net_DNS2_RR_HINFO extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->formatString($this->cpu) . ' ' . 
             $this->formatString($this->os);

--- a/Net/DNS2/RR/HIP.php
+++ b/Net/DNS2/RR/HIP.php
@@ -122,7 +122,7 @@ class Net_DNS2_RR_HIP extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         $out = $this->pk_algorithm . ' ' . 
             $this->hit . ' ' . $this->public_key . ' ';

--- a/Net/DNS2/RR/IPSECKEY.php
+++ b/Net/DNS2/RR/IPSECKEY.php
@@ -128,7 +128,7 @@ class Net_DNS2_RR_IPSECKEY extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         $out = $this->precedence . ' ' . $this->gateway_type . ' ' . 
             $this->algorithm . ' ';

--- a/Net/DNS2/RR/ISDN.php
+++ b/Net/DNS2/RR/ISDN.php
@@ -85,7 +85,7 @@ class Net_DNS2_RR_ISDN extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->formatString($this->isdnaddress) . ' ' . 
             $this->formatString($this->sa);

--- a/Net/DNS2/RR/KX.php
+++ b/Net/DNS2/RR/KX.php
@@ -89,7 +89,7 @@ class Net_DNS2_RR_KX extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->preference . ' ' . $this->cleanString($this->exchange) . '.';
     }

--- a/Net/DNS2/RR/L32.php
+++ b/Net/DNS2/RR/L32.php
@@ -86,7 +86,7 @@ class Net_DNS2_RR_L32 extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->preference . ' ' . $this->locator32;
     }

--- a/Net/DNS2/RR/L64.php
+++ b/Net/DNS2/RR/L64.php
@@ -88,7 +88,7 @@ class Net_DNS2_RR_L64 extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->preference . ' ' . $this->locator64;
     }

--- a/Net/DNS2/RR/LOC.php
+++ b/Net/DNS2/RR/LOC.php
@@ -135,7 +135,7 @@ class Net_DNS2_RR_LOC extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         if ($this->version == 0) {
 

--- a/Net/DNS2/RR/LP.php
+++ b/Net/DNS2/RR/LP.php
@@ -88,7 +88,7 @@ class Net_DNS2_RR_LP extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->preference . ' ' . $this->fqdn . '.';
     }

--- a/Net/DNS2/RR/MX.php
+++ b/Net/DNS2/RR/MX.php
@@ -86,7 +86,7 @@ class Net_DNS2_RR_MX extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->preference . ' ' . $this->cleanString($this->exchange) . '.';
     }

--- a/Net/DNS2/RR/NAPTR.php
+++ b/Net/DNS2/RR/NAPTR.php
@@ -117,7 +117,7 @@ class Net_DNS2_RR_NAPTR extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->order . ' ' . $this->preference . ' ' . 
             $this->formatString($this->flags) . ' ' . 

--- a/Net/DNS2/RR/NID.php
+++ b/Net/DNS2/RR/NID.php
@@ -88,7 +88,7 @@ class Net_DNS2_RR_NID extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->preference . ' ' . $this->nodeid;
     }

--- a/Net/DNS2/RR/NIMLOC.php
+++ b/Net/DNS2/RR/NIMLOC.php
@@ -70,7 +70,7 @@ class Net_DNS2_RR_NIMLOC extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return '';
     }

--- a/Net/DNS2/RR/NS.php
+++ b/Net/DNS2/RR/NS.php
@@ -79,7 +79,7 @@ class Net_DNS2_RR_NS extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->cleanString($this->nsdname) . '.';
     }

--- a/Net/DNS2/RR/NSAP.php
+++ b/Net/DNS2/RR/NSAP.php
@@ -89,7 +89,7 @@ class Net_DNS2_RR_NSAP extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->cleanString($this->afi) . '.' . 
             $this->cleanString($this->idi) . '.' . 

--- a/Net/DNS2/RR/NSEC.php
+++ b/Net/DNS2/RR/NSEC.php
@@ -86,7 +86,7 @@ class Net_DNS2_RR_NSEC extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         $data = $this->cleanString($this->next_domain_name) . '.';
 

--- a/Net/DNS2/RR/NSEC3.php
+++ b/Net/DNS2/RR/NSEC3.php
@@ -120,7 +120,7 @@ class Net_DNS2_RR_NSEC3 extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         $out = $this->algorithm . ' ' . $this->flags . ' ' . $this->iterations . ' ';
  

--- a/Net/DNS2/RR/NSEC3PARAM.php
+++ b/Net/DNS2/RR/NSEC3PARAM.php
@@ -103,7 +103,7 @@ class Net_DNS2_RR_NSEC3PARAM extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         $out = $this->algorithm . ' ' . $this->flags . ' ' . $this->iterations . ' ';
 

--- a/Net/DNS2/RR/OPENPGPKEY.php
+++ b/Net/DNS2/RR/OPENPGPKEY.php
@@ -81,7 +81,7 @@ class Net_DNS2_RR_OPENPGPKEY extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->key;
     }

--- a/Net/DNS2/RR/OPT.php
+++ b/Net/DNS2/RR/OPT.php
@@ -153,7 +153,7 @@ class Net_DNS2_RR_OPT extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->option_code . ' ' . $this->option_data;
     }

--- a/Net/DNS2/RR/PTR.php
+++ b/Net/DNS2/RR/PTR.php
@@ -78,7 +78,7 @@ class Net_DNS2_RR_PTR extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return rtrim($this->ptrdname, '.') . '.';
     }

--- a/Net/DNS2/RR/PX.php
+++ b/Net/DNS2/RR/PX.php
@@ -94,7 +94,7 @@ class Net_DNS2_RR_PX extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->preference . ' ' . $this->cleanString($this->map822) . '. ' . 
             $this->cleanString($this->mapx400) . '.';

--- a/Net/DNS2/RR/RP.php
+++ b/Net/DNS2/RR/RP.php
@@ -87,7 +87,7 @@ class Net_DNS2_RR_RP extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->cleanString($this->mboxdname) . '. ' . 
             $this->cleanString($this->txtdname) . '.';

--- a/Net/DNS2/RR/RRSIG.php
+++ b/Net/DNS2/RR/RRSIG.php
@@ -159,7 +159,7 @@ class Net_DNS2_RR_RRSIG extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->typecovered . ' ' . $this->algorithm . ' ' . 
             $this->labels . ' ' . $this->origttl . ' ' .

--- a/Net/DNS2/RR/RT.php
+++ b/Net/DNS2/RR/RT.php
@@ -86,7 +86,7 @@ class Net_DNS2_RR_RT extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->preference . ' ' . 
             $this->cleanString($this->intermediatehost) . '.';

--- a/Net/DNS2/RR/SIG.php
+++ b/Net/DNS2/RR/SIG.php
@@ -164,7 +164,7 @@ class Net_DNS2_RR_SIG extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->typecovered . ' ' . $this->algorithm . ' ' . 
             $this->labels . ' ' . $this->origttl . ' ' .

--- a/Net/DNS2/RR/SOA.php
+++ b/Net/DNS2/RR/SOA.php
@@ -126,7 +126,7 @@ class Net_DNS2_RR_SOA extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->cleanString($this->mname) . '. ' . 
             $this->cleanString($this->rname) . '. ' . 

--- a/Net/DNS2/RR/SRV.php
+++ b/Net/DNS2/RR/SRV.php
@@ -99,7 +99,7 @@ class Net_DNS2_RR_SRV extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->priority . ' ' . $this->weight . ' ' . 
             $this->port . ' ' . $this->cleanString($this->target) . '.';

--- a/Net/DNS2/RR/SSHFP.php
+++ b/Net/DNS2/RR/SSHFP.php
@@ -110,7 +110,7 @@ class Net_DNS2_RR_SSHFP extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->algorithm . ' ' . $this->fp_type . ' ' . $this->fingerprint;
     }

--- a/Net/DNS2/RR/TALINK.php
+++ b/Net/DNS2/RR/TALINK.php
@@ -87,7 +87,7 @@ class Net_DNS2_RR_TALINK extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->cleanString($this->previous) . '. ' . 
             $this->cleanString($this->next) . '.';

--- a/Net/DNS2/RR/TKEY.php
+++ b/Net/DNS2/RR/TKEY.php
@@ -124,7 +124,7 @@ class Net_DNS2_RR_TKEY extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         $out = $this->cleanString($this->algorithm) . '. ' . $this->mode;
         if ($this->key_size > 0) {

--- a/Net/DNS2/RR/TLSA.php
+++ b/Net/DNS2/RR/TLSA.php
@@ -98,7 +98,7 @@ class Net_DNS2_RR_TLSA extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->cert_usage . ' ' . $this->selector . ' ' . 
             $this->matching_type . ' ' . base64_encode($this->certificate);

--- a/Net/DNS2/RR/TSIG.php
+++ b/Net/DNS2/RR/TSIG.php
@@ -165,7 +165,7 @@ class Net_DNS2_RR_TSIG extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         $out = $this->cleanString($this->algorithm) . '. ' . 
             $this->time_signed . ' ' . 

--- a/Net/DNS2/RR/TXT.php
+++ b/Net/DNS2/RR/TXT.php
@@ -78,7 +78,7 @@ class Net_DNS2_RR_TXT extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         if (count($this->text) == 0) {
             return '""';

--- a/Net/DNS2/RR/TYPE65534.php
+++ b/Net/DNS2/RR/TYPE65534.php
@@ -78,7 +78,7 @@ class Net_DNS2_RR_TYPE65534 extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return base64_encode($this->private_data);
     }

--- a/Net/DNS2/RR/URI.php
+++ b/Net/DNS2/RR/URI.php
@@ -92,7 +92,7 @@ class Net_DNS2_RR_URI extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         //
         // presentation format has double quotes (") around the target.

--- a/Net/DNS2/RR/WKS.php
+++ b/Net/DNS2/RR/WKS.php
@@ -94,7 +94,7 @@ class Net_DNS2_RR_WKS extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         $data = $this->address . ' ' . $this->protocol;
 

--- a/Net/DNS2/RR/X25.php
+++ b/Net/DNS2/RR/X25.php
@@ -78,7 +78,7 @@ class Net_DNS2_RR_X25 extends Net_DNS2_RR
      * @access  protected
      *
      */
-    protected function rrToString()
+    public function rrToString()
     {
         return $this->formatString($this->psdnaddress);
     }


### PR DESCRIPTION
For a project I'm developing, it would be beneficial to use the `rrToString` method. However, because of its current `protected` visibility, this is not possible. This PR changes the visibility to `public`. As far as I know this would not cause a breaking change, except for people overriding the `Net_DNS2_RR_*`classes, who use that method name and return something else. But I don't think that many people go that route.