### PR TITLE
PHP 7.4 compatibility: Fix parameter order of implode()

### DIFF
--- a/Net/DNS2/RR/CAA.php
+++ b/Net/DNS2/RR/CAA.php
@@ -112,7 +112,7 @@ class Net_DNS2_RR_CAA extends Net_DNS2_RR
         $this->flags    = array_shift($rdata);
         $this->tag      = array_shift($rdata);
 
-        $this->value    = trim($this->cleanString(implode($rdata, ' ')), '"');
+        $this->value    = trim($this->cleanString(implode(' ', $rdata)), '"');
         
         return true;
     }


### PR DESCRIPTION
As per the [change notes on the manual page](https://www.php.net/implode#refsect1-function.implode-changelog), the alternative parameter order is deprecated.

This was picked up when performing a scan on my project with the [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) CodeSniffer extension.

Neither PHPCompatibility or a manual search found any other instances of implode() using the alternative parameter order.