### PR TITLE
TYPE65534 presentation format issue

### DIFF
--- a/Net/DNS2/Packet.php
+++ b/Net/DNS2/Packet.php
@@ -286,14 +286,15 @@ class Net_DNS2_Packet
      * This logic was based on the Net::DNS::Packet::dn_expand() function
      * by Michanel Fuhr
      *
-     * @param Net_DNS2_Packet &$packet the DNS packet to look in for the domain name
-     * @param integer         &$offset the offset into the given packet object
+     * @param Net_DNS2_Packet &$packet     the DNS packet to look in for the domain name
+     * @param integer         &$offset     the offset into the given packet object
+     * @param boolean         $escape_dots whether to escape literal dots found in some labels (for example, in SOA rname fields)
      *
      * @return mixed either the domain name or null if it's not found.
      * @access public
      *
      */
-    public static function expand(Net_DNS2_Packet &$packet, &$offset)
+    public static function expand(Net_DNS2_Packet &$packet, &$offset, $escape_dots=false)
     {
         $name = '';
 
@@ -338,6 +339,12 @@ class Net_DNS2_Packet
 
                 $elem = '';
                 $elem = substr($packet->rdata, $offset, $xlen);
+
+                if ($escape_dots && false !== strpos($elem, '.')) {
+                    // label contains a literal dot which must be escaped
+                    $elem = str_replace('.', '\.', $elem);
+                }
+
                 $name .= $elem . '.';
                 $offset += $xlen;
             }

--- a/Net/DNS2/RR/SOA.php
+++ b/Net/DNS2/RR/SOA.php
@@ -176,7 +176,7 @@ class Net_DNS2_RR_SOA extends Net_DNS2_RR
             $offset = $packet->offset;
 
             $this->mname = Net_DNS2_Packet::expand($packet, $offset);
-            $this->rname = Net_DNS2_Packet::expand($packet, $offset);
+            $this->rname = Net_DNS2_Packet::expand($packet, $offset, true);
 
             //
             // get the SOA values


### PR DESCRIPTION
The `rrToString()` and `rrFromString()` methods of `Net_DNS2_RR_TYPE65534` don't quite comply with the specification in [RFC 3597](https://tools.ietf.org/html/rfc3597), which causes interoperability issues.

These methods assume that the record rdata is a single base64-encoded string. However, the correct presentation format for these records is (for example):

```
example.com 3600 IN TYPE65534 \# 5 081E700001
```

The first field can be ignored. The second field is the length of the data, and the third is the binary data encoded in hexadecimal.

This pull request updates the `rrToString()` and `rrFromString()` methods to comply with the above presentation format (for output and input respectively).