### PR TITLE
Issue with literal dots in SOA rname field

### DIFF
--- a/Net/DNS2/Packet.php
+++ b/Net/DNS2/Packet.php
@@ -288,12 +288,13 @@ class Net_DNS2_Packet
      *
      * @param Net_DNS2_Packet &$packet the DNS packet to look in for the domain name
      * @param integer         &$offset the offset into the given packet object
+     * @param boolean         $escape_dots whether to escape literal dots found in some labels (for example, in SOA rname fields)
      *
      * @return mixed either the domain name or null if it's not found.
      * @access public
      *
      */
-    public static function expand(Net_DNS2_Packet &$packet, &$offset)
+    public static function expand(Net_DNS2_Packet &$packet, &$offset, $escape_dots=false)
     {
         $name = '';
 
@@ -338,6 +339,12 @@ class Net_DNS2_Packet
 
                 $elem = '';
                 $elem = substr($packet->rdata, $offset, $xlen);
+
+                if ($escape_dots && false !== strpos($elem, '.')) {
+                    // label contains a literal dot which must be escaped
+                    $elem = str_replace('.', '\.', $elem);
+                }
+
                 $name .= $elem . '.';
                 $offset += $xlen;
             }

--- a/Net/DNS2/RR/SOA.php
+++ b/Net/DNS2/RR/SOA.php
@@ -176,7 +176,7 @@ class Net_DNS2_RR_SOA extends Net_DNS2_RR
             $offset = $packet->offset;
 
             $this->mname = Net_DNS2_Packet::expand($packet, $offset);
-            $this->rname = Net_DNS2_Packet::expand($packet, $offset);
+            $this->rname = Net_DNS2_Packet::expand($packet, $offset, true);
 
             //
             // get the SOA values


### PR DESCRIPTION
If a label in the `rname` field of an SOA record has a literal dot, this is not escaped when `Net_DNS2_RR_SOA::rrSet()` parses the RR from the packet. As a result, an email address like `foo.bar@example.com`, which encodes to `foo\.bar@example.com` in presentation format, is parsed to `foo.bar.example.com`, which is incorrect (it would be converted into `foo@bar.example.com` by an application).

This pull request adds an optional `$escape_dots` argument to `Net_DNS2_Packet::expand()`. This causes any dots found in a label to be escaped. This argument is `false` by default, but is set to `true` when `Net_DNS2_RR_SOA::rrSet()` calls the `escape()` method to read the `rname` field.

This change can be tested with the following:

```php
<?php

require 'Net/DNS2.php';

$resolver = new Net_DNS2_Resolver;

$result = $resolver->query('kommpower.de.', 'SOA');

echo $result->answer[0]."\n";
```
Before the change is applied, this will output something like this:

```
kommpower.de. 180 IN SOA margherita.activeminds.net. h.merguet.merguet.de. 2020022403 10800 3600 604800 10800
```

Afterwards, it will output this:

```
kommpower.de. 180 IN SOA margherita.activeminds.net. h\.merguet.merguet.de. 2020022403 10800 3600 604800 10800
```

Compare with the output of `dig`:

```
$ dig +noall +answer SOA kommpower.de
kommpower.de.		180	IN	SOA	margherita.activeminds.net. h\.merguet.merguet.de. 2020022403 10800 3600 604800 10800
```

Literal dots may also be present in `RP` and `MINFO` records, however `MINFO` isn't implemented in `Net_DNS2`. `RP` records are exceedingly rare. It would be simple enough to patch `Net_DNS2_RR_RP::rrSet()` to set the `$escape_dots` parameter to `Net_DNS2_Packet::expand()`.