### PR TITLE
Issue with psr-0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
     },
     "autoload": {
         "psr-0": { "Net_DNS2": "" }
+    },
+    "autoload": {
+        "psr-0": { "Tests_Net_DNS2": "tests/" }
     }
 }

--- a/package.xml
+++ b/package.xml
@@ -117,10 +117,10 @@ This release is (in most cases) 2x - 10x faster than Net_DNS, as well as include
    <file baseinstalldir="/" md5sum="a589db31b862ac5308eaacf9c2223ae1" name="Net/DNS2/RR/X25.php" role="php" />
    <file baseinstalldir="/" md5sum="6b88e0b40fe820dea5dc28149c98a792" name="Net/DNS2/Socket/Sockets.php" role="php" />
    <file baseinstalldir="/" md5sum="6c80cb53453ad0837532004c91e14dd7" name="Net/DNS2/Socket/Streams.php" role="php" />
-   <file baseinstalldir="/" md5sum="3830c26904fd0ecdcd9b40af7aed3bb6" name="tests/AllTests.php" role="test" />
-   <file baseinstalldir="/" md5sum="edadf1d417c229b25166677ae608baa7" name="tests/Net_DNS2_DNSSECTest.php" role="test" />
-   <file baseinstalldir="/" md5sum="0c6ee7b01f564952c3a7f9b69ce8d85a" name="tests/Net_DNS2_ParserTest.php" role="test" />
-   <file baseinstalldir="/" md5sum="3667edbb50ebfa4089bb678168f1899f" name="tests/Net_DNS2_ResolverTest.php" role="test" />
+   <file baseinstalldir="/" md5sum="3e70e41fba9ca537689f0246d2891c5e" name="tests/Tests_Net_DNS2_AllTests.php" role="test" />
+   <file baseinstalldir="/" md5sum="1d99f542ce6eddc2a574d7eef729a5fe" name="tests/Tests_Net_DNS2_DNSSECTest.php" role="test" />
+   <file baseinstalldir="/" md5sum="45f5dbbb9b5c67aa9674dc9e5aa2403a" name="tests/Tests_Net_DNS2_ParserTest.php" role="test" />
+   <file baseinstalldir="/" md5sum="32f515bc864f1d3a1861f1cb04636bec" name="tests/Tests_Net_DNS2_ResolverTest.php" role="test" />
    <file baseinstalldir="/" md5sum="9290a83f15bd81ff0af2e0149d17fd1d" name="LICENSE" role="doc" />
    <file baseinstalldir="/" md5sum="ffcaea84e3ca0d168ed4861c19d19049" name="README.md" role="doc" />
   </dir>

--- a/tests/Tests_Net_DNS2_AllTests.php
+++ b/tests/Tests_Net_DNS2_AllTests.php
@@ -50,41 +50,65 @@
  *
  */
 
-require_once '../Net/DNS2.php';
+error_reporting(E_ALL | E_STRICT);
 
-/**  
- * This test uses the Google public DNS servers to perform a resolution test; 
- * this should work on *nix and Windows, but will require an internet connection.
- * 
+if (!defined('PHPUNIT_MAIN_METHOD')) {
+    define('PHPUNIT_MAIN_METHOD', 'Tests_Net_DNS2_AllTests::main');
+}
+
+require_once 'Tests_Net_DNS2_ParserTest.php';
+require_once 'Tests_Net_DNS2_ResolverTest.php';
+require_once 'Tests_Net_DNS2_DNSSECTest.php';
+
+set_include_path('..:.');
+
+/**
+ * This test suite assumes that Net_DNS2 will be in the include path, otherwise it
+ * will fail. There's no other way to hardcode a include_path in here that would
+ * make it work everywhere.
+ *
  * @category Networking
  * @package  Net_DNS2
  * @author   Mike Pultz <mike@mikepultz.com>
  * @license  http://www.opensource.org/licenses/bsd-license.php  BSD License
- * @link     http://pear.php.net/package/Net_DNS2      
+ * @link     http://pear.php.net/package/Net_DNS2
  *
  */
-class Net_DNS2_ResolverTest extends PHPUnit_Framework_TestCase
+class Tests_Net_DNS2_AllTests
 {
     /**
-     * function to test the resolver
+     * the main runner
      *
      * @return void
      * @access public
-     * 
+     *
      */
-    public function testResolver()
+    public static function main()
     {
-        $ns = array('8.8.8.8', '8.8.4.4');
-
-        $r = new Net_DNS2_Resolver(array('nameservers' => $ns));
-
-        $result = $r->query('google.com', 'MX');
-
-        $this->assertSame($result->header->qr, Net_DNS2_Lookups::QR_RESPONSE);
-        $this->assertSame(count($result->question), 1);
-        $this->assertTrue(count($result->answer) > 0);
-        $this->assertTrue($result->answer[0] instanceof Net_DNS2_RR_MX);
+        PHPUnit_TextUI_TestRunner::run(self::suite());
     }
+
+    /**
+     * test suite
+     *
+     * @return void
+     * @access public
+     *
+     */
+    public static function suite()
+    {
+        $suite = new PHPUnit_Framework_TestSuite('PEAR - Net_DNS2');
+
+        $suite->addTestSuite('Tests_Net_DNS2_ParserTest');
+        $suite->addTestSuite('Tests_Net_DNS2_ResolverTest');
+        $suite->addTestSuite('Tests_Net_DNS2_DNSSECTest');
+
+        return $suite;
+    }
+}
+
+if (PHPUNIT_MAIN_METHOD == 'Tests_Net_DNS2_AllTests::main') {
+    Tests_Net_DNS2_AllTests::main();
 }
 
 ?>

--- a/tests/Tests_Net_DNS2_DNSSECTest.php
+++ b/tests/Tests_Net_DNS2_DNSSECTest.php
@@ -50,65 +50,41 @@
  *
  */
 
-error_reporting(E_ALL | E_STRICT);
-
-if (!defined('PHPUNIT_MAIN_METHOD')) {
-    define('PHPUNIT_MAIN_METHOD', 'Net_DNS2_AllTests::main');
-}
-
-require_once 'Net_DNS2_ParserTest.php';
-require_once 'Net_DNS2_ResolverTest.php';
-require_once 'Net_DNS2_DNSSECTest.php';
-
-set_include_path('..:.');
+require_once '../Net/DNS2.php';
 
 /**
- * This test suite assumes that Net_DNS2 will be in the include path, otherwise it
- * will fail. There's no other way to hardcode a include_path in here that would 
- * make it work everywhere.
+ * Test class to test the DNSSEC logic
  *
  * @category Networking
  * @package  Net_DNS2
  * @author   Mike Pultz <mike@mikepultz.com>
  * @license  http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link     http://pear.php.net/package/Net_DNS2
- * 
+ *
  */
-class Net_DNS2_AllTests
+class Tests_Net_DNS2_DNSSECTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * the main runner
+     * function to test the TSIG logic
      *
      * @return void
      * @access public
-     *     
-     */
-    public static function main()
-    {
-        PHPUnit_TextUI_TestRunner::run(self::suite());
-    }
-
-    /**
-     * test suite
      *
-     * @return void
-     * @access public
-     *     
      */
-    public static function suite()
+    public function testDNSSEC()
     {
-        $suite = new PHPUnit_Framework_TestSuite('PEAR - Net_DNS2');
+        $ns = array('8.8.8.8', '8.8.4.4');
 
-        $suite->addTestSuite('Net_DNS2_ParserTest');
-        $suite->addTestSuite('Net_DNS2_ResolverTest');
-        $suite->addTestSuite('Net_DNS2_DNSSECTest');
+        $r = new Net_DNS2_Resolver(array('nameservers' => $ns));
 
-        return $suite;
+        $r->dnssec = true;
+
+        $result = $r->query('org', 'SOA', 'IN');
+
+        $this->assertTrue(($result->header->ad == 1));
+        $this->assertTrue(($result->additional[0] instanceof Net_DNS2_RR_OPT));
+        $this->assertTrue(($result->additional[0]->do == 1));
     }
-}
-
-if (PHPUNIT_MAIN_METHOD == 'Net_DNS2_AllTests::main') {
-    Net_DNS2_AllTests::main();
-}
+};
 
 ?>

--- a/tests/Tests_Net_DNS2_ParserTest.php
+++ b/tests/Tests_Net_DNS2_ParserTest.php
@@ -55,7 +55,7 @@ require_once '../Net/DNS2.php';
 
 /**
  * Test class to test the parsing code
- *   
+ *
  * @category Networking
  * @package  Net_DNS2
  * @author   Mike Pultz <mike@mikepultz.com>
@@ -63,7 +63,7 @@ require_once '../Net/DNS2.php';
  * @link     http://pear.php.net/package/Net_DNS2
  *
  */
-class Net_DNS2_ParserTest extends PHPUnit_Framework_TestCase
+class Tests_Net_DNS2_ParserTest extends PHPUnit_Framework_TestCase
 {
     /**
      * function to test the TSIG logic
@@ -91,8 +91,8 @@ class Net_DNS2_ParserTest extends PHPUnit_Framework_TestCase
         $request->additional[] = Net_DNS2_RR::fromString('mykey TSIG Zm9vYmFy');
         $request->header->arcount = 1;
 
-        $line = $request->additional[0]->name . '. ' . $request->additional[0]->ttl . ' ' . 
-        $request->additional[0]->class . ' ' . $request->additional[0]->type . ' ' . 
+        $line = $request->additional[0]->name . '. ' . $request->additional[0]->ttl . ' ' .
+        $request->additional[0]->class . ' ' . $request->additional[0]->type . ' ' .
         $request->additional[0]->algorithm . '. ' . $request->additional[0]->time_signed  . ' '.
         $request->additional[0]->fudge;
 
@@ -200,10 +200,10 @@ class Net_DNS2_ParserTest extends PHPUnit_Framework_TestCase
             $a = Net_DNS2_RR::fromString($line);
 
             //
-            // check that the object is right 
+            // check that the object is right
             //
             $this->assertTrue($a instanceof $class_name);
-                        
+
             //
             // set it on the packet
             //
@@ -214,7 +214,7 @@ class Net_DNS2_ParserTest extends PHPUnit_Framework_TestCase
             // get the binary packet data
             //
             $data = $request->get();
-                        
+
             //
             // parse the binary
             //
@@ -273,10 +273,10 @@ class Net_DNS2_ParserTest extends PHPUnit_Framework_TestCase
             $a = Net_DNS2_RR::fromString($line);
 
             //
-            // check that the object is right 
+            // check that the object is right
             //
             $this->assertTrue($a instanceof $class_name);
-                        
+
             //
             // set it on the packet
             //

--- a/tests/Tests_Net_DNS2_ResolverTest.php
+++ b/tests/Tests_Net_DNS2_ResolverTest.php
@@ -53,7 +53,8 @@
 require_once '../Net/DNS2.php';
 
 /**
- * Test class to test the DNSSEC logic
+ * This test uses the Google public DNS servers to perform a resolution test;
+ * this should work on *nix and Windows, but will require an internet connection.
  *
  * @category Networking
  * @package  Net_DNS2
@@ -62,29 +63,28 @@ require_once '../Net/DNS2.php';
  * @link     http://pear.php.net/package/Net_DNS2
  *
  */
-class Net_DNS2_DNSSECTest extends PHPUnit_Framework_TestCase
+class Tests_Net_DNS2_ResolverTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * function to test the TSIG logic
+     * function to test the resolver
      *
      * @return void
      * @access public
      *
      */
-    public function testDNSSEC()
+    public function testResolver()
     {
         $ns = array('8.8.8.8', '8.8.4.4');
 
         $r = new Net_DNS2_Resolver(array('nameservers' => $ns));
 
-        $r->dnssec = true;
+        $result = $r->query('google.com', 'MX');
 
-        $result = $r->query('org', 'SOA', 'IN');
-
-        $this->assertTrue(($result->header->ad == 1));
-        $this->assertTrue(($result->additional[0] instanceof Net_DNS2_RR_OPT));
-        $this->assertTrue(($result->additional[0]->do == 1));
+        $this->assertSame($result->header->qr, Net_DNS2_Lookups::QR_RESPONSE);
+        $this->assertSame(count($result->question), 1);
+        $this->assertTrue(count($result->answer) > 0);
+        $this->assertTrue($result->answer[0] instanceof Net_DNS2_RR_MX);
     }
-};
+}
 
 ?>


### PR DESCRIPTION
Deprecation Notice: Class Net_DNS2_ParserTest located in ./vendor/pear/net_dns2/tests/Net_DNS2_ParserTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201

Deprecation Notice: Class Net_DNS2_AllTests located in ./vendor/pear/net_dns2/tests/AllTests.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201

Deprecation Notice: Class Net_DNS2_ResolverTest located in ./vendor/pear/net_dns2/tests/Net_DNS2_ResolverTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201

Deprecation Notice: Class Net_DNS2_DNSSECTest located in ./vendor/pear/net_dns2/tests/Net_DNS2_DNSSECTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201