### PR TITLE
Fix composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "autoload": {
         "psr-0": { "Net_DNS2": "" }
     },
-    "autoload": {
+    "autoload-dev": {
         "psr-0": { "Tests_Net_DNS2": "tests/" }
     }
 }


### PR DESCRIPTION
The duplicate autoload key is causing only the tests to be autoloaded when installing version 1.5.0 using composer.