### PR TITLE
Check "filesize() > 0" before fread

### DIFF
--- a/Net/DNS2/Cache/File.php
+++ b/Net/DNS2/Cache/File.php
@@ -139,7 +139,12 @@ class Net_DNS2_Cache_File extends Net_DNS2_Cache
             //
             // read the file contents
             //
-            $data = @fread($fp, filesize($this->cache_file));
+            $data = false;
+            
+            if (filesize($this->cache_file) > 0) {
+                $data = @fread($fp, filesize($this->cache_file));
+            ]
+            
             if ( ($data !== false) && (strlen($data) > 0) ) {
 
                 //

--- a/Net/DNS2/Cache/File.php
+++ b/Net/DNS2/Cache/File.php
@@ -143,7 +143,7 @@ class Net_DNS2_Cache_File extends Net_DNS2_Cache
             
             if (filesize($this->cache_file) > 0) {
                 $data = @fread($fp, filesize($this->cache_file));
-            ]
+            }
             
             if ( ($data !== false) && (strlen($data) > 0) ) {
 


### PR DESCRIPTION
This fixes the following error in PHP 8:
`Fatal error: Uncaught ValueError: fread(): Argument #2 ($length) must be greater than 0`