### PR TITLE
Mute stream_select warnings

### DIFF
--- a/Net/DNS2/Socket.php
+++ b/Net/DNS2/Socket.php
@@ -333,7 +333,7 @@ class Net_DNS2_Socket
         //
         // select on read
         //
-        $result = stream_select($read, $write, $except, $this->timeout);
+        $result = @stream_select($read, $write, $except, $this->timeout);
         if ($result === false) {
 
             $this->last_error = 'error on read select()';


### PR DESCRIPTION
We're running DNS validations in background queues, where sometimes the following error can pop-up:

`stream_select(): unable to select [4]: Interrupted system call (max_fd=18)`

I think it's safe to suppress this. 