### PR TITLE
Fix local_host default value to avoid notices in PHP 8.1

### DIFF
--- a/Net/DNS2/Socket.php
+++ b/Net/DNS2/Socket.php
@@ -43,7 +43,7 @@ class Net_DNS2_Socket
     /*
      * the local IP and port we'll send the request from
      */
-    private $local_host;
+    private $local_host = '';
     private $local_port;
 
     /*


### PR DESCRIPTION
When $local_host property is not initialized (null), notice is raised in PHP 8.1 when calling `strlen($this->local_host)`