### PR TITLE
Fix warning for certain queries

### DIFF
--- a/Net/DNS2/Question.php
+++ b/Net/DNS2/Question.php
@@ -134,10 +134,10 @@ class Net_DNS2_Question
         //
         // validate it
         //
-        $type_name  = Net_DNS2_Lookups::$rr_types_by_id[$type];
-        $class_name = Net_DNS2_Lookups::$classes_by_id[$class];
+        $type_name  = Net_DNS2_Lookups::$rr_types_by_id[$type] ?? false;
+        $class_name = Net_DNS2_Lookups::$classes_by_id[$class] ?? false;
 
-        if ( (!isset($type_name)) || (!isset($class_name)) ) {
+        if ( false === $type_name || false === $class_name ) {
 
             throw new Net_DNS2_Exception(
                 'invalid question section: invalid type (' . $type . 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or download the source above.
 
 ## Requirements ##
 
-* PHP 5.4+
+* PHP 7.4+
 * The PHP INI setting `mbstring.func_overload` equals 0, 1, 4, or 5.
 
 


### PR DESCRIPTION
This will fix #141.

However since the null coalesence operator is only available in PHP 7.4 or newer, the minimum required PHP version will also be increased to 7.4 - but since even PHP 7.4 is already end of life, this should not be a problem (also see #142).