### PR TITLE
Prevent TCP segmentation

### DIFF
--- a/Net/DNS2/Socket.php
+++ b/Net/DNS2/Socket.php
@@ -283,12 +283,8 @@ class Net_DNS2_Socket
         if ($this->type == Net_DNS2_Socket::SOCK_STREAM) {
 
             $s = chr($length >> 8) . chr($length);
-
-            if (@fwrite($this->sock, $s) === false) {
-
-                $this->last_error = 'failed to fwrite() 16bit length';
-                return false;
-            }
+            $data = $s . $data;
+            $length = strlen($data);
         }
 
         //


### PR DESCRIPTION
### Issue
When using TCP (`\Net_DNS2_Resolver::$use_tcp = true`), then certain DNS systems may refuse to answer the DNS query due to (I assume) unintentional TCP segmentation.

### Cause
When writing data to the TCP socket (using PHP's `fwrite()`), PHP immediately sends the data using the TCP flags `PSH` and `ACK`. As a result, the TCP receiver might try to process the first TCP segment (which does only contain the length of the DNS-query, but not the actual query itself). The latter will obviously fail and the receiver will instantly close the connection using a TCP `RST` packet, resulting in refusing to accept the actual DNS-query which is sent in the second TCP segment.

### Solution
`fwrite()` must only be called once, containing both the length of the DNS query along with the actual query.