### PR TITLE
Fix PHP 8.4 deprecation messages

### DIFF
--- a/Net/DNS2.php
+++ b/Net/DNS2.php
@@ -226,7 +226,7 @@ class Net_DNS2
      * @access public
      *
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         //
         // load any options that were provided

--- a/Net/DNS2/Notifier.php
+++ b/Net/DNS2/Notifier.php
@@ -47,7 +47,7 @@ class Net_DNS2_Notifier extends Net_DNS2
      * @access public
      *
      */
-    public function __construct($zone, array $options = null)
+    public function __construct($zone, ?array $options = null)
     {
         parent::__construct($options);
 

--- a/Net/DNS2/RR.php
+++ b/Net/DNS2/RR.php
@@ -139,7 +139,7 @@ abstract class Net_DNS2_RR
      * @access public
      *
      */
-    public function __construct(Net_DNS2_Packet &$packet = null, array $rr = null)
+    public function __construct(?Net_DNS2_Packet &$packet = null, array $rr = null)
     {
         if ( (!is_null($packet)) && (!is_null($rr)) ) {
 

--- a/Net/DNS2/RR/CERT.php
+++ b/Net/DNS2/RR/CERT.php
@@ -93,7 +93,7 @@ class Net_DNS2_RR_CERT extends Net_DNS2_RR
      * @return
      *
      */
-    public function __construct(Net_DNS2_Packet &$packet = null, array $rr = null)
+    public function __construct(?Net_DNS2_Packet &$packet = null, array $rr = null)
     {
         parent::__construct($packet, $rr);
     

--- a/Net/DNS2/RR/OPT.php
+++ b/Net/DNS2/RR/OPT.php
@@ -81,7 +81,7 @@ class Net_DNS2_RR_OPT extends Net_DNS2_RR
      * @access public
      *
      */
-    public function __construct(Net_DNS2_Packet &$packet = null, array $rr = null)
+    public function __construct(?Net_DNS2_Packet &$packet = null, array $rr = null)
     {
         //
         // this is for when we're manually building an OPT RR object; we aren't

--- a/Net/DNS2/Resolver.php
+++ b/Net/DNS2/Resolver.php
@@ -31,7 +31,7 @@ class Net_DNS2_Resolver extends Net_DNS2
      * @access public
      *
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         parent::__construct($options);
     }

--- a/Net/DNS2/Updater.php
+++ b/Net/DNS2/Updater.php
@@ -48,7 +48,7 @@ class Net_DNS2_Updater extends Net_DNS2
      * @access public
      *
      */
-    public function __construct($zone, array $options = null)
+    public function __construct($zone, ?array $options = null)
     {
         parent::__construct($options);
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4"
+        "php": ">=7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9"


### PR DESCRIPTION
fix PHP 8.4 deprecation messages Implicitly marking parameter as nullable is deprecated.