### PR TITLE
Fixed PHPStan issue

### DIFF
--- a/src/NetDNS2/Notifier.php
+++ b/src/NetDNS2/Notifier.php
@@ -140,11 +140,12 @@ final class Notifier extends \NetDNS2\Client
      * executes the notify request
      *
      * @param \NetDNS2\Packet\Response &$_response ref to the response object
+     * @param-out \NetDNS2\Packet\Response $_response
      *
      * @throws \NetDNS2\Exception
      *
      */
-    public function notify(?\NetDNS2\Packet\Response &$_response = null): void  // @phpstan-ignore parameterByRef.unusedType
+    public function notify(?\NetDNS2\Packet\Response &$_response = null): void
     {
         //
         // init some network settings

--- a/src/NetDNS2/Updater.php
+++ b/src/NetDNS2/Updater.php
@@ -428,11 +428,12 @@ final class Updater extends \NetDNS2\Client
      * executes the update request with the object informaton
      *
      * @param \NetDNS2\Packet\Response &$_response ref to the response object
+     * @param-out \NetDNS2\Packet\Response $_response
      *
      * @throws \NetDNS2\Exception
      *
      */
-    public function update(?\NetDNS2\Packet\Response &$_response = null): bool  // @phpstan-ignore parameterByRef.unusedType
+    public function update(?\NetDNS2\Packet\Response &$_response = null): bool
     {
         //
         // init some network settings


### PR DESCRIPTION
The fix for #160 mentioned some PHPStan errors which were ignored at the time.

This change resolves the errors by specifying the param-out type without null.