### PR TITLE
Fix: Use instanceof to correctly detect SOA records in AXFR

### DIFF
--- a/src/NetDNS2/Client.php
+++ b/src/NetDNS2/Client.php
@@ -1033,7 +1033,7 @@ class Client
                         //
                         // count the SOA records
                         //
-                        if ($rr->type == 'SOA')
+                        if ($rr instanceof \NetDNS2\RR\SOA)
                         {
                             $soa_count++;
                         }
@@ -1060,7 +1060,7 @@ class Client
                         //
                         // count the number of SOA records we find
                         //
-                        if ($rr->type == 'SOA')
+                        if ($rr instanceof \NetDNS2\RR\SOA)
                         {
                             $soa_count++;
                         }


### PR DESCRIPTION
The Problem

When performing an AXFR query where the server sends the entire zone transfer in a single TCP packet (including both the starting and ending SOA record), the library fails to detect the end of the transfer. This is because the code checks for the record type using $rr->type == 'SOA', which fails for NetDNS2\ENUM\RR\Type objects. This leads to an infinite loop that ends in a timeout on read select() error.

The Solution

This PR fixes the issue by changing the type check from a string comparison to instanceof \NetDNS2\RR\SOA. This correctly identifies the SOA records, allowing the loop to terminate properly when two SOA records are found in the response.